### PR TITLE
Recommendation links endpoint

### DIFF
--- a/recommender/conf/routes
+++ b/recommender/conf/routes
@@ -7,3 +7,4 @@ GET        /healthcheck                             controllers.Application.heal
 GET        /recommendations/browsers/:browserId     controllers.Application.recommendationsFromBrowserId(browserId, webPublicationDate: Option[DateRangeFilter], tags: Option[QueryBoost], disableDateFilter: Option[Boolean], pageSize: Option[Int])
 GET        /recommendations/users/me                controllers.Application.recommendationsForMe(webPublicationDate: Option[DateRangeFilter], tags: Option[QueryBoost], disableDateFilter: Option[Boolean], pageSize: Option[Int])
 POST       /recommendations                         controllers.Application.recommendationsFromArticleIds
+POST       /recommendationlinks                     controllers.Application.recommendationLinksFromArticleIds

--- a/recommender/conf/routes
+++ b/recommender/conf/routes
@@ -6,5 +6,4 @@ GET        /healthcheck                             controllers.Application.heal
 
 GET        /recommendations/browsers/:browserId     controllers.Application.recommendationsFromBrowserId(browserId, webPublicationDate: Option[DateRangeFilter], tags: Option[QueryBoost], disableDateFilter: Option[Boolean], pageSize: Option[Int])
 GET        /recommendations/users/me                controllers.Application.recommendationsForMe(webPublicationDate: Option[DateRangeFilter], tags: Option[QueryBoost], disableDateFilter: Option[Boolean], pageSize: Option[Int])
-POST       /recommendations                         controllers.Application.recommendationsFromArticleIds
-POST       /recommendationlinks                     controllers.Application.recommendationLinksFromArticleIds
+POST       /recommendations                         controllers.Application.recommendations(format: Option[String])


### PR DESCRIPTION
In this PR I've added an optional parameter called `format` to the `/recommendations` route which allows the client to specify the format of the recommendation results. The options are `mapi_items` (default) or `mapi_links`. The `mapi_items` option yields fully hydrated MAPI article items, whereas the `mapi_links` option yields results like this:

```
{"score":4.655040264129639,"item":"http://mobile-apps.guardianapis.com/items/environment/2016/aug/19/sea-potatoes-urchins-wash-up-en-masse-on-cornish-beach"}
```

In this case the client must hydrate the results itself.
