### PR TITLE
Gatling test for recommender

### DIFF
--- a/gatling/.gitignore
+++ b/gatling/.gitignore
@@ -1,0 +1,1 @@
+dev.properties

--- a/gatling/build.sbt
+++ b/gatling/build.sbt
@@ -1,6 +1,12 @@
+enablePlugins(GatlingPlugin)
+
 name := "gatling"
 
 version := "1.0"
 
 scalaVersion := "2.11.8"
-    
+
+libraryDependencies := Seq(
+  "io.gatling.highcharts" % "gatling-charts-highcharts" % "2.1.7" % "test",
+  "io.gatling"            % "gatling-test-framework"    % "2.1.7" % "test"
+)

--- a/gatling/build.sbt
+++ b/gatling/build.sbt
@@ -1,0 +1,6 @@
+name := "gatling"
+
+version := "1.0"
+
+scalaVersion := "2.11.8"
+    

--- a/gatling/build.sbt
+++ b/gatling/build.sbt
@@ -10,3 +10,5 @@ libraryDependencies := Seq(
   "io.gatling.highcharts" % "gatling-charts-highcharts" % "2.1.7" % "test",
   "io.gatling"            % "gatling-test-framework"    % "2.1.7" % "test"
 )
+
+libraryDependencies +=  "org.scalaj" %% "scalaj-http" % "2.3.0"

--- a/gatling/dev.properties
+++ b/gatling/dev.properties
@@ -1,0 +1,1 @@
+capi.api_key=test

--- a/gatling/project/build.properties
+++ b/gatling/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version = 0.13.8

--- a/gatling/project/plugins.sbt
+++ b/gatling/project/plugins.sbt
@@ -1,0 +1,1 @@
+logLevel := Level.Warn

--- a/gatling/project/plugins.sbt
+++ b/gatling/project/plugins.sbt
@@ -1,1 +1,2 @@
+addSbtPlugin("io.gatling" % "gatling-sbt" % "2.1.7")
 logLevel := Level.Warn

--- a/gatling/src/test/scala/recommender/BasicSimulation.scala
+++ b/gatling/src/test/scala/recommender/BasicSimulation.scala
@@ -64,7 +64,7 @@ class BasicSimulation extends Simulation {
 
   //setUp(scn.inject(atOnceUsers(1)).protocols(httpConf))
   setUp(scn.inject(
-    rampUsersPerSec(1) to(75) during(30 seconds),
-    constantUsersPerSec(75) during(300 seconds) randomized
+    rampUsersPerSec(1) to(50) during(30 seconds),
+    constantUsersPerSec(50) during(900 seconds) randomized
   )).protocols(httpConf)
 }

--- a/gatling/src/test/scala/recommender/BasicSimulation.scala
+++ b/gatling/src/test/scala/recommender/BasicSimulation.scala
@@ -3,24 +3,19 @@ package recommender
 import io.gatling.core.Predef._
 import io.gatling.http.Predef._
 import scala.concurrent.duration._
-import io.gatling.core.validation.Validation
 
 
 class BasicSimulation extends Simulation {
-  val routerUrl = "https://mobile.code.dev-guardianapis.com/fronts"
-  val originUrl = "http://engine.mobile.guardianapis.com"
-  //val originUrl = "http://localhost:9000"
+  val baseUrl = "http://engine.mobile.guardianapis.com"
+  //val baseUrl = "http://localhost:9000"
+
   val httpConf = http
-    .baseURL(originUrl) // Here is the root for all relative URLs
+    .baseURL(baseUrl) // Here is the root for all relative URLs
     .acceptHeader("text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8") // Here are the common headers
     .doNotTrackHeader("1")
     .acceptLanguageHeader("en-US,en;q=0.5")
     .acceptEncodingHeader("gzip, deflate")
     .userAgentHeader("Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:48.0) Gecko/20100101 Firefox/48.0")
-
-  def fromOrigin(s: String): Session => Validation[String] = { session =>
-    session(s).as[String].replace(routerUrl, originUrl)
-  }
 
   val scn = scenario("Get recommendations") // A scenario is a chain of requests and pauses
     .exec(http("healthcheck")

--- a/gatling/src/test/scala/recommender/BasicSimulation.scala
+++ b/gatling/src/test/scala/recommender/BasicSimulation.scala
@@ -1,0 +1,57 @@
+package recommender
+
+import io.gatling.core.Predef._
+import io.gatling.http.Predef._
+import scala.concurrent.duration._
+import io.gatling.core.validation.Validation
+
+
+class BasicSimulation extends Simulation {
+  val routerUrl = "https://mobile.code.dev-guardianapis.com/fronts"
+  val originUrl = "http://engine.mobile.guardianapis.com"
+  //val originUrl = "http://localhost:9000"
+  val httpConf = http
+    .baseURL(originUrl) // Here is the root for all relative URLs
+    .acceptHeader("text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8") // Here are the common headers
+    .doNotTrackHeader("1")
+    .acceptLanguageHeader("en-US,en;q=0.5")
+    .acceptEncodingHeader("gzip, deflate")
+    .userAgentHeader("Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:48.0) Gecko/20100101 Firefox/48.0")
+
+  def fromOrigin(s: String): Session => Validation[String] = { session =>
+    session(s).as[String].replace(routerUrl, originUrl)
+  }
+
+  val scn = scenario("Get recommendations") // A scenario is a chain of requests and pauses
+    .exec(http("healthcheck")
+    .get("/healthcheck")
+    .check(status.is(200))
+  )
+    /*
+    .pause(20.milliseconds) // Note that Gatling has recorded real time pauses
+    .exec(http("get home front")
+    .get(fromOrigin("frontUri"))
+    .check(jsonPath("$.layout[*]").ofType[Map[String, Any]].findAll.saveAs("layouts"))
+  )
+    .pause(20.milliseconds)
+    .foreach("${layouts}", "layout") {
+      exec({session =>
+        val layoutMap = session("layout").as[Map[String, Any]]
+        val containerUri = layoutMap("uri")
+        session.set("containerUri", containerUri)
+      }).exec(http("get container uri")
+        .get(fromOrigin("containerUri"))
+        .check(jsonPath("$.cards[0].item.links.relatedUri").optional.saveAs("relatedUri"))
+      )
+        .pause(20.milliseconds)
+        .doIf(session => session.contains("relatedUri")) {
+          exec(http("get related items")
+            .get(fromOrigin("relatedUri"))
+          )
+        }
+
+    }
+    */
+
+  setUp(scn.inject(rampUsers(50).over(30 seconds)).protocols(httpConf)) // was 100
+}

--- a/recommender/.gitignore
+++ b/recommender/.gitignore
@@ -1,1 +1,2 @@
 logs/
+conf/gu-conf

--- a/recommender/README.md
+++ b/recommender/README.md
@@ -4,18 +4,16 @@
 
 ### To configure
 
-You must set the properties below in the file `conf/gu-conf/DEV.properties`. The values for
-`elasticsearch.hosts` and `apis.userhistory.apiKey` are omitted, speak to @davidfurey or
-@maxspencer to get them:
+    cp conf/gu-conf/SAMPLE.properties conf/gu-conf/DEV.properties
 
-    apis.predictionio.base=http://engine.mobile-aws.guardianapis.com:8000/queries.json
-    apis.mobile-api.items.base=http://mobile-apps.guardianapis.com/items
-    elasticsearch.hosts=
-    apis.userhistory.apiKey=
-    apis.userhistory.base=https://user-history.guardianapis.com/v1
-    
-Next you must create a file `/etc/gu/install_vars` with the contents `INT_SERVICE_DOMAIN=DEV`
-to ensure the config is loaded from the `DEV.properties` file.
+Then open `DEV.properties` and fill in the values for the `elasticsearch.hosts` and
+`apis.userhistory.apiKey` properties which are ommitted for security reasons, speak to
+@davidfurey or @maxspencer to get them. Note: files in `conf/gu-conf` are ignored by
+Git.
+
+    echo "INT_SERVICE_DOMAIN=DEV" >> /etc/gu/install_vars
+
+To ensure the config is loaded from the `DEV.properties` file.
 
 ### To run
 

--- a/recommender/conf/gu-conf/DEV.properties
+++ b/recommender/conf/gu-conf/DEV.properties
@@ -1,6 +1,0 @@
-#
-# Default settings for developing locally
-#
-
-apis.predictionio.base=
-apis.mobile-api.items.base=

--- a/recommender/conf/gu-conf/SAMPLE.properties
+++ b/recommender/conf/gu-conf/SAMPLE.properties
@@ -1,0 +1,7 @@
+# Sample settings with some sensitive values ommitted
+
+apis.predictionio.base=http://engine.mobile-aws.guardianapis.com:8000/queries.json
+apis.mobile-api.items.base=http://mobile-apps.guardianapis.com/items
+elasticsearch.hosts=
+apis.userhistory.apiKey=
+apis.userhistory.base=https://user-history.guardianapis.com/v1


### PR DESCRIPTION
The gatling test get all of the articles published today from CAPI, and chooses a random sample of 40-50 of them to send to the `/recommendations` endpoint.

This PR also includes some changes to how the `DEV.properties` file is handled by git so that it doesn't keep nagging you to commit its contents.
