### PR TITLE
Auto discover elastic search cluster for spark-conf

### DIFF
--- a/engine/engine.json
+++ b/engine/engine.json
@@ -19,8 +19,8 @@
     "spark.executor.memory": "10g",
     "spark.default.parallelism": "4",
     "es.index.auto.create": "true",
-    "es.nodes": "10.248.6.137,10.248.4.26,10.248.5.199",
-    "es.nodes.discovery": "false"
+    "es.nodes": "${elasticsearch_host}",
+    "es.nodes.discovery": "true"
   },
   "algorithms": [
     {

--- a/train/files/setup.sh
+++ b/train/files/setup.sh
@@ -60,6 +60,7 @@ cp /root/files/terminate-clusters.sh PredictionIO-0.9.5/bin/
 cp /root/files/update-yarn-config.sh PredictionIO-0.9.5/bin/
 cp /root/files/discover-elasticsearch-cluster.sh PredictionIO-0.9.5/bin/
 cp /root/files/update-pio-config.sh PredictionIO-0.9.5/bin/
+cp /root/files/update-engine-config.sh PredictionIO-0.9.5/bin/
 cp /root/files/set-asg-size.sh PredictionIO-0.9.5/bin/
 
 # Fix java home

--- a/train/files/train.sh
+++ b/train/files/train.sh
@@ -14,6 +14,7 @@ cd /opt/PredictionIO-0.9.5/
 yarn_master=$(bin/discover-spark-cluster.sh $STAGE)
 bin/update-yarn-config.sh $STAGE $yarn_master
 bin/update-pio-config.sh $STAGE
+bin/update-engine-config.sh $STAGE
 cd /opt/PredictionIO-0.9.5/engines/MyGuardianTestEngine-1
 time ../../bin/pio train -- --master yarn --deploy-mode client --driver-memory 1200M --verbose
 cd /opt/PredictionIO-0.9.5/

--- a/train/files/update-engine-config.sh
+++ b/train/files/update-engine-config.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -e
+
+STAGE=$1
+
+if [ "$STAGE" != "PROD" ] && [ "$STAGE" != "CODE" ]; then
+    echo "Missing/invalid argument STAGE (valid stages are PROD or CODE)" 1>&2
+    exit 1
+fi
+
+elasticsearch_host=$(bin/discover-elasticsearch-cluster.sh $STAGE | head -1)
+
+if [ ! -e "/opt/PredictionIO-0.9.5/engines/MyGuardianTestEngine-1/engine.json.template" ]; then
+    cp /opt/PredictionIO-0.9.5/engines/MyGuardianTestEngine-1/engine.json /opt/PredictionIO-0.9.5/engines/MyGuardianTestEngine-1/engine.json.template
+fi
+
+sed /opt/PredictionIO-0.9.5/engines/MyGuardianTestEngine-1/engine.json.template \
+    -e "s/\${elasticsearch_host}/$elasticsearch_host/g" \
+    > /opt/PredictionIO-0.9.5/engines/MyGuardianTestEngine-1/engine.json


### PR DESCRIPTION
Because we shouldn't need to create pull-requests because a node went down.