### PR TITLE
Catch elastic search exceptions as failed futures

### DIFF
--- a/recommender/app/lib/ElasticSearchFuture.scala
+++ b/recommender/app/lib/ElasticSearchFuture.scala
@@ -1,0 +1,29 @@
+package lib
+
+import org.elasticsearch.action.{ActionListener, ListenableActionFuture}
+import play.Logger
+
+import scala.concurrent.{Future, Promise}
+import scala.util.{Success, Try, Failure}
+
+object ElasticSearchFuture {
+  def safe[T](result: => ListenableActionFuture[T]): Future[T] = {
+    Try(result) match {
+      case Success(r) =>
+        val promise = Promise[T]()
+        r.addListener(new ActionListener[T] {
+          def onFailure(e: Throwable) {
+            Logger.error("Elasticsearch query failure", e)
+            promise.failure(e)
+          }
+          def onResponse(response: T) {
+            promise.success(response)
+          }
+        })
+        promise.future
+      case Failure(e) =>
+        Logger.error("Elasticsearch query failure", e)
+        Future.failed(e)
+    }
+  }
+}

--- a/recommender/app/lib/ElasticSearchImplicits.scala
+++ b/recommender/app/lib/ElasticSearchImplicits.scala
@@ -29,20 +29,4 @@ object ElasticSearchImplicits {
     def optAndThen(fn: T => Option[T]): T = fn(qb).getOrElse(qb)
     def optAndThen(optFn: Option[T => T]): T = optFn.map(_(qb)).getOrElse(qb)
   }
-
-  implicit class EnrichedListenableActionFuture[T](result: ListenableActionFuture[T]) {
-    def asScala = {
-      val promise = Promise[T]()
-      result.addListener(new ActionListener[T] {
-        def onFailure(e: Throwable) {
-          Logger.error("Elasticsearch query failure", e)
-          promise.failure(e)
-        }
-        def onResponse(response: T) {
-          promise.success(response)
-        }
-      })
-      promise.future
-    }
-  }
 }


### PR DESCRIPTION
ES queries can throw exceptions before the ListenableActionFuture is
created.  Kaka’s scheduler stops repeating if the runnable throws an
exception.  This combination means that if the cluster is unreachable,
the healthcheck fails and then never runs again.

Catching this early exception and wrapping it as a failed future should
fix this.